### PR TITLE
Gtokenizers example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,218 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml
+
+data/sample/raw_h5ad

--- a/demo/Data Preprocessing.ipynb
+++ b/demo/Data Preprocessing.ipynb
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "1dd2c0ce",
    "metadata": {
     "ExecuteTime": {
@@ -98,57 +98,38 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "***** WARNING: File data/sample/fragment/HCAHeartST10773171_HCAHeartST10781448.bed has inconsistent naming convention for record:\n",
-      "GL000194.1\t74048\t74109\tACAAAGGTCCTAAGTA-1\t5\n",
-      "\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Overlap calculation between fragments and cCREs completed.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "***** WARNING: File data/sample/fragment/HCAHeartST10773171_HCAHeartST10781448.bed has inconsistent naming convention for record:\n",
-      "GL000194.1\t74048\t74109\tACAAAGGTCCTAAGTA-1\t5\n",
-      "\n"
      ]
     }
    ],
    "source": [
     "# Python code to execute shell script for bedtools intersect\n",
     "import os\n",
-    "import subprocess\n",
+    "\n",
+    "from gtars.tokenizers import Tokenizer, tokenize_fragment_file\n",
+    "\n",
     "# Define paths\n",
     "CCRE_FILE_PATH = \"../data/cCRE.bed\"\n",
     "INPUT_DIR = \"../data/sample/fragment/\"\n",
-    "OUTPUT_DIR = \"../data/sample/output_intersect/\"\n",
     "\n",
-    "# Ensure the output directory exists\n",
-    "os.makedirs(OUTPUT_DIR, exist_ok=True)\n",
+    "# dictionary to hold fragment tokens\n",
+    "# each fragments file gets tokenized into a dictionary of barcode: token list (input ids)\n",
+    "fragments_to_tokens = {}\n",
+    "tokenizer = Tokenizer.from_bed(CCRE_FILE_PATH)\n",
+    "unk_token_id = tokenizer.unk_token_id\n",
     "\n",
     "# Iterate through .bed files in the input directory\n",
     "for fragments_file in os.listdir(INPUT_DIR):\n",
     "    if fragments_file.endswith(\".bed\"):\n",
     "        basename = os.path.splitext(fragments_file)[0]\n",
-    "        output_file = os.path.join(OUTPUT_DIR, f\"{basename}.bed\")\n",
-    "\n",
-    "        # Construct bedtools command\n",
-    "        command = (\n",
-    "            f\"bedtools intersect -a {os.path.join(INPUT_DIR, fragments_file)} \"\n",
-    "            f\"-b {CCRE_FILE_PATH} -wa -wb > {output_file}\"\n",
-    "        )\n",
-    "\n",
-    "        # Execute the command\n",
-    "        subprocess.run(command, shell=True, check=True)\n",
+    "        fragment_file_path = os.path.join(INPUT_DIR, fragments_file)\n",
+    "        fragments_to_tokens[basename] = tokenize_fragment_file(fragment_file_path, tokenizer)\n",
+    "        # filter out unk_token_id entries\n",
+    "        fragments_to_tokens[basename] = {barcode: [token for token in tokens if token != unk_token_id]\n",
+    "                                         for barcode, tokens in fragments_to_tokens[basename].items()}\n",
     "\n",
     "print(\"Overlap calculation between fragments and cCREs completed.\")"
    ]
@@ -171,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "id": "9202ee4c",
    "metadata": {
     "ExecuteTime": {
@@ -181,39 +162,47 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generated data/sample/raw_h5ad/HCAHeartST10773171_HCAHeartST10781448.h5ad\n"
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'epiagent'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mModuleNotFoundError\u001b[39m                       Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mepiagent\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mpreprocessing\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m construct_cell_by_ccre_matrix_from_fragments_tokens\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpandas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpd\u001b[39;00m\n\u001b[32m      4\u001b[39m \u001b[38;5;66;03m# Process all intersect files\u001b[39;00m\n",
+      "\u001b[31mModuleNotFoundError\u001b[39m: No module named 'epiagent'"
      ]
     }
    ],
    "source": [
-    "from epiagent.preprocessing import construct_cell_by_ccre_matrix\n",
+    "from epiagent.preprocessing import construct_cell_by_ccre_matrix_from_fragments_tokens\n",
     "import pandas as pd\n",
+    "\n",
     "# Process all intersect files\n",
     "ccre_bed_path = \"../data/cCRE.bed\"\n",
     "output_directory = \"../data/sample/raw_h5ad/\"\n",
     "os.makedirs(output_directory, exist_ok=True)\n",
     "\n",
-    "for intersect_file in os.listdir(\"../data/sample/output_intersect/\"):\n",
-    "    if intersect_file.endswith(\".bed\"):\n",
-    "        output_file_path = os.path.join(\"../data/sample/output_intersect/\", intersect_file)\n",
-    "        output_filename = intersect_file.replace('.bed', '.h5ad')\n",
-    "        final_output_path = os.path.join(output_directory, output_filename)\n",
+    "num_ccre = tokenizer.vocab_size = len(tokenizer.special_tokens_map)\n",
     "\n",
-    "        # Construct AnnData\n",
-    "        adata = construct_cell_by_ccre_matrix(output_file_path, ccre_bed_path)\n",
+    "for file_basename in fragments_to_tokens.keys():        \n",
+    "    output_filename = f\"{file_basename}.h5ad\"\n",
+    "    final_output_path = os.path.join(output_directory, output_filename)\n",
     "\n",
-    "        # Optional: Add metadata\n",
-    "        metadata = pd.read_csv('../data/sample/metadata.csv', index_col=0)\n",
-    "        prefix = output_filename.split('.')[0]  # Remove file suffix\n",
-    "        adata.obs.index = prefix + '_' + adata.obs.index\n",
-    "        adata.obs = adata.obs.join(metadata, how='left')\n",
+    "    # Construct AnnData\n",
+    "    adata = construct_cell_by_ccre_matrix_from_fragments_tokens(\n",
+    "        fragments_tokens=fragments_to_tokens[file_basename],\n",
+    "        num_ccre=num_ccre,\n",
+    "    )\n",
     "\n",
-    "        # Save AnnData\n",
-    "        adata.write(final_output_path)\n",
-    "        print(f\"Generated {final_output_path}\")"
+    "    # Optional: Add metadata\n",
+    "    metadata = pd.read_csv('../data/sample/metadata.csv', index_col=0)\n",
+    "    prefix = output_filename.split('.')[0]  # Remove file suffix\n",
+    "    adata.obs.index = prefix + '_' + adata.obs.index\n",
+    "    adata.obs = adata.obs.join(metadata, how='left')\n",
+    "\n",
+    "    # Save AnnData\n",
+    "    adata.write(final_output_path)\n",
+    "    print(f\"Generated {final_output_path}\")"
    ]
   },
   {
@@ -598,7 +587,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "EpiAgent",
    "language": "python",
    "name": "python3"
   },
@@ -612,7 +601,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "version": "3.13.1"
   },
   "toc": {
    "base_numbering": 1,

--- a/epiagent/preprocessing.py
+++ b/epiagent/preprocessing.py
@@ -5,6 +5,30 @@ import pandas as pd
 from scipy.sparse import csr_matrix
 from scipy.sparse import coo_matrix
 
+def construct_cell_by_ccre_matrix_from_fragments_tokens(
+    fragments_tokens: dict[str, list[int]],
+    num_ccre: int,
+) -> AnnData:
+    """
+    Constructs a cell-by-cCRE matrix from fragment tokens.
+
+    Args:
+        fragments_tokens (dict): A dictionary mapping cell barcodes to lists of cCRE token indices.
+        num_ccre (int): The number of cCREs.
+    Returns:
+        AnnData: An AnnData object containing the cell-by-cCRE matrix.
+    """
+    ncells = len(set(fragments_tokens.keys()))
+    mat = np.zeros((ncells, num_ccre), dtype=np.int8)
+    for i, (_, tokens) in enumerate(fragments_tokens.items()):
+        mat[i, tokens] += 1
+    
+    mat = csr_matrix(mat)
+    obs_names = pd.DataFrame(index=pd.Index(list(fragments_tokens.keys()), name="cell_barcode"))
+    var = pd.DataFrame(index=pd.Index([f"cCRE_{i}" for i in range(num_ccre)], name="cCRE_id"))
+    return AnnData(X=mat, obs=obs_names, var=var)
+
+
 def construct_cell_by_ccre_matrix(intersect_file, ccre_bed_path):
     """
     Constructs a cell-by-cCRE matrix from intersect results and cCRE definitions.


### PR DESCRIPTION
Addressing #4 

Hi @xy-chen16 

This is an example of using `gtokenizers` to perform the tokenization step to align a fragments file to the EpiAgent vocabulary/universe/cCRE set.

Theres really only two steps here:
1. Create a tokenizer and use the `tokenize_fragment_file` utility to get a barcode-to-input-ids mapping:
```python
{
  'ATGATCAGCTA': [101, 202, 345],
  'GTTGATCGATA': [123, 987, 1098]
}
```
2. Flip this to a CSR matrix format for use with `AnnData` objects.

Essentially, we are just performing what `bedtools` does, but we are doing it 1) much much faster (using [AIList](https://academic.oup.com/bioinformatics/article/35/23/4907/5509521)), and 2) all in memory so we don't need to be writing to disk.

Let me know if you think this is useful or if you have any questions!

PS you didn't have a gitignore, so I added one to avoid committing `__pycache__` dirs.